### PR TITLE
Move service into config and make sure we use UTC time.

### DIFF
--- a/spec/aws_signer_spec.cr
+++ b/spec/aws_signer_spec.cr
@@ -6,6 +6,7 @@ describe AwsSigner do
       config.access_key = "AKIDEXAMPLE"
       config.secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
       config.region = "us-east-1"
+      config.service = "host"
     end
   end
 

--- a/spec/aws_signer_spec.cr
+++ b/spec/aws_signer_spec.cr
@@ -6,7 +6,6 @@ describe AwsSigner do
       config.access_key = "AKIDEXAMPLE"
       config.secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
       config.region = "us-east-1"
-      config.service = "host"
     end
   end
 
@@ -18,6 +17,7 @@ describe AwsSigner do
     }
     body = ""
     signed = AwsSigner.sign(
+      "host",
       "GET",
       uri,
       headers,
@@ -35,7 +35,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("GET", uri, headers, body)
+    signed = AwsSigner.sign("host", "GET", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470")
@@ -48,7 +48,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("GET", uri, headers, body)
+    signed = AwsSigner.sign("host", "GET", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470")
@@ -61,7 +61,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("GET", uri, headers, body)
+    signed = AwsSigner.sign("host", "GET", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=910e4d6c9abafaf87898e1eb4c929135782ea25bb0279703146455745391e63a")
@@ -74,7 +74,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("GET", uri, headers, body)
+    signed = AwsSigner.sign("host", "GET", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470")
@@ -87,7 +87,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("GET", uri, headers, body)
+    signed = AwsSigner.sign("host", "GET", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=56c054473fd260c13e4e7393eb203662195f5d4a1fada5314b8b52b23f985e9f")
@@ -100,7 +100,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("GET", uri, headers, body)
+    signed = AwsSigner.sign("host", "GET", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=830cc36d03f0f84e6ee4953fbe701c1c8b71a0372c63af9255aa364dd183281e")
@@ -114,7 +114,7 @@ describe AwsSigner do
       "p"    => " phfft ",
     }
     body = ""
-    signed = AwsSigner.sign("POST", uri, headers, body)
+    signed = AwsSigner.sign("host", "POST", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;p, Signature=debf546796015d6f6ded8626f5ce98597c33b47b9164cf6b17b4642036fcb592")
@@ -127,7 +127,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("GET", uri, headers, body)
+    signed = AwsSigner.sign("host", "GET", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=be7148d34ebccdc6423b19085378aa0bee970bdc61d144bd1a8c48c33079ab09")
@@ -140,7 +140,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("GET", uri, headers, body)
+    signed = AwsSigner.sign("host", "GET", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=0dc122f3b28b831ab48ba65cb47300de53fbe91b577fe113edac383730254a3b")
@@ -154,7 +154,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("GET", uri, headers, body)
+    signed = AwsSigner.sign("host", "GET", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=6fb359e9a05394cc7074e0feb42573a2601abc0c869a953e8c5c12e4e01f1a8c")
@@ -167,7 +167,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("POST", uri, headers, body)
+    signed = AwsSigner.sign("host", "POST", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=22902d79e148b64e7571c3565769328423fe276eae4b26f83afceda9e767f726")
@@ -180,7 +180,7 @@ describe AwsSigner do
       "Date" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("POST", uri, headers, body)
+    signed = AwsSigner.sign("host", "POST", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b6e3b79003ce0743a491606ba1035a804593b0efb1e20a11cba83f8c25a57a92")
@@ -194,7 +194,7 @@ describe AwsSigner do
       "ZOO"  => "zoobar",
     }
     body = ""
-    signed = AwsSigner.sign("POST", uri, headers, body)
+    signed = AwsSigner.sign("host", "POST", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;zoo, Signature=b7a95a52518abbca0964a999a880429ab734f35ebbf1235bd79a5de87756dc4a")
@@ -207,7 +207,7 @@ describe AwsSigner do
       "DATE" => "Mon, 09 Sep 2011 23:36:00 GMT",
     }
     body = ""
-    signed = AwsSigner.sign("POST", uri, headers, body)
+    signed = AwsSigner.sign("host", "POST", uri, headers, body)
     signed["DATE"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=22902d79e148b64e7571c3565769328423fe276eae4b26f83afceda9e767f726")
@@ -221,7 +221,7 @@ describe AwsSigner do
       "zoo"  => "ZOOBAR",
     }
     body = ""
-    signed = AwsSigner.sign("POST", uri, headers, body)
+    signed = AwsSigner.sign("host", "POST", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Authorization"].should eq("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;zoo, Signature=273313af9d0c265c531e11db70bbd653f3ba074c1009239e8559d3987039cad7")
@@ -235,7 +235,7 @@ describe AwsSigner do
       "Content-Type" => "application/x-www-form-urlencoded",
     }
     body = "foo=bar"
-    signed = AwsSigner.sign("POST", uri, headers, body)
+    signed = AwsSigner.sign("host", "POST", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Content-Type"].should eq("application/x-www-form-urlencoded")
@@ -250,7 +250,7 @@ describe AwsSigner do
       "Content-Type" => "application/x-www-form-urlencoded; charset=utf8",
     }
     body = "foo=bar"
-    signed = AwsSigner.sign("POST", uri, headers, body)
+    signed = AwsSigner.sign("host", "POST", uri, headers, body)
     signed["Date"].should eq("Mon, 09 Sep 2011 23:36:00 GMT")
     signed["Host"].should eq("host.foo.com")
     signed["Content-Type"].should eq("application/x-www-form-urlencoded; charset=utf8")

--- a/src/aws_signer.cr
+++ b/src/aws_signer.cr
@@ -19,7 +19,7 @@ module AwsSigner
     @@configuration ||= Config.new
   end
 
-  def self.sign(method : String, uri : URI, headers : Hash(String, String), body : String) : Hash(String, String)
+  def self.sign(service : String, method : String, uri : URI, headers : Hash(String, String), body : String) : Hash(String, String)
     method = method.upcase
 
     headers_array = headers.to_a
@@ -32,7 +32,6 @@ module AwsSigner
     end.join("\n") + "\n"
 
     host = uri.host.as(String)
-    service = config.service
 
     date_header = headers["Date"]? || headers["DATE"]? || headers["date"]?
     date_to_parse = date_header ? parse_time(date_header) : Time.now.to_utc

--- a/src/aws_signer.cr
+++ b/src/aws_signer.cr
@@ -32,10 +32,10 @@ module AwsSigner
     end.join("\n") + "\n"
 
     host = uri.host.as(String)
-    service = host.split(".", 2)[0]
+    service = config.service
 
     date_header = headers["Date"]? || headers["DATE"]? || headers["date"]?
-    date_to_parse = date_header ? parse_time(date_header) : Time.now
+    date_to_parse = date_header ? parse_time(date_header) : Time.now.to_utc
 
     begin
       date_to_parse = date_to_parse.as(Time)

--- a/src/aws_signer/config.cr
+++ b/src/aws_signer/config.cr
@@ -3,7 +3,6 @@ module AwsSigner
     @access_key : String?
     @secret_key : String?
     @region : String?
-    @service : String?
 
     def access_key=(access_key)
       @access_key = access_key
@@ -27,14 +26,6 @@ module AwsSigner
 
     def region
       @region.as(String)
-    end
-
-    def service=(service)
-      @service = service
-    end
-
-    def service
-      @service.as(String)
     end
   end
 end

--- a/src/aws_signer/config.cr
+++ b/src/aws_signer/config.cr
@@ -3,6 +3,7 @@ module AwsSigner
     @access_key : String?
     @secret_key : String?
     @region : String?
+    @service : String?
 
     def access_key=(access_key)
       @access_key = access_key
@@ -26,6 +27,14 @@ module AwsSigner
 
     def region
       @region.as(String)
+    end
+
+    def service=(service)
+      @service = service
+    end
+
+    def service
+      @service.as(String)
     end
   end
 end


### PR DESCRIPTION
I had two issues when I was trying to use this shard:
- I am making requests to S3 and the host includes the bucket name _bucket.s3.amazonaws.com_ so getting the service name from the host is not the best thus I moved it to the configuration object
- the time when not coming from the header is not in UTC

With theses changes now I'm able to make successful requests to S3.
